### PR TITLE
Disable empty sources in search results by default.

### DIFF
--- a/app/src/main/kotlin/io/github/landwarderer/futon/search/ui/multi/SearchViewModel.kt
+++ b/app/src/main/kotlin/io/github/landwarderer/futon/search/ui/multi/SearchViewModel.kt
@@ -63,7 +63,7 @@ class SearchViewModel @Inject constructor(
 
 	private var includeDisabledSources = MutableStateFlow(false)
 	private var pinnedOnly = MutableStateFlow(false)
-	private var hideEmpty = MutableStateFlow(false)
+	private var hideEmpty = MutableStateFlow(true)
 	private val results = MutableStateFlow<List<SearchResultsListModel>>(emptyList())
 
 	private var searchJob: Job? = null

--- a/app/src/main/res/menu/opt_search_kind.xml
+++ b/app/src/main/res/menu/opt_search_kind.xml
@@ -44,6 +44,7 @@
 				<item
 					android:id="@+id/action_filter_hide_empty"
 					android:checkable="true"
+                    android:checked="true"
 					android:title="@string/hide_empty_sources" />
 
 			</group>


### PR DESCRIPTION
This removes all sources that are not working and just clutter up when you search.
"hide empy sources"checkbox will be enabled by default (user can choose to view empty sources by unchecking).
