### PR TITLE
v9.6.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on "Keep a Changelog" and follows semantic versioning where possible.
 
 ## [Unreleased]
+## 9.7
+Date: Late March 2026
+
+### Highlights
+- UI reworks and new features.
 
 - (Work in progress)
+
+
+---
+## v9.6.13
+Date: 2026-03-15
+
+### Highlights
+- Made Crash Analytics opt-in only, disabled by default.
+
+### Fixes
+- Fixed Build Fail due to missing Sentry auth token.
 
 ---
 
 ## v9.6.12
-Date: (see tag)
+Date: 2026-03-12
 
 ### Highlights
 - Added opt-in crash analytics (Sentry) — disabled by default, can be enabled in Settings.
@@ -22,7 +38,7 @@ Date: (see tag)
 ---
 
 ## v9.6.11
-Date: (see tag)
+Date: 2026-02-27
 
 ### Highlights
 - Added 'Reading' quick filter (#30).
@@ -40,7 +56,7 @@ Date: (see tag)
 ---
 
 ## v9.6.10
-Date: (see tag)
+Date: 2026-01-02
 
 ### Highlights
 - Resource cleanup and translation fixes.
@@ -55,7 +71,7 @@ Date: (see tag)
 ---
 
 ## v9.6.9
-Date: (see tag)
+Date: 2025-12-31
 
 ### Highlights
 - Parser upgrade and stability improvements.
@@ -67,7 +83,7 @@ Date: (see tag)
 ---
 
 ## v9.6.8
-Date: (see tag)
+Date: 2025-12-30
 
 ### Highlights
 - Packaging and version alignment.
@@ -79,7 +95,7 @@ Date: (see tag)
 ---
 
 ## v9.6.7
-Date: (see tag)
+Date: 2025-12-29
 
 ### Highlights
 - Stability fixes and minor packaging updates.
@@ -90,7 +106,7 @@ Date: (see tag)
 ---
 
 ## v9.6.6
-Date: (see tag)
+Date: 2025-12-27
 
 ### Highlights
 - Build and tooling maintenance.
@@ -101,7 +117,7 @@ Date: (see tag)
 ---
 
 ## v9.6.5
-Date: (see tag)
+Date: 2025-12-27
 
 ### Highlights
 - Build file updates and minor fixes.
@@ -112,7 +128,7 @@ Date: (see tag)
 ---
 
 ## v9.6.4
-Date: (see tag)
+Date: 2025-12-24
 
 ### Highlights
 - Hotfix: build/syntax correction.
@@ -123,7 +139,7 @@ Date: (see tag)
 ---
 
 ## v9.6.3
-Date: (see tag)
+Date: 2025-12-23
 
 ### Highlights
 - Downloads UX and wording updates.
@@ -135,7 +151,7 @@ Date: (see tag)
 ---
 
 ## v9.6.2
-Date: (see tag)
+Date: 2025-12-22
 
 ### Highlights
 - EventFlow reliability improvements.
@@ -172,7 +188,7 @@ Date: 2025-12-21
 ---
 
 ## v9.5
-Date: (see tag)
+Date: 2025-12-11
 
 ### Highlights
 - Added Downloads viewer and UX improvements.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
 		applicationId 'io.github.landwarderer.futon'
 		minSdk = 23
 		targetSdk = 36
-		versionCode project.hasProperty('versionCode') ? project.property('versionCode').toInteger() : 90612
-        versionName project.hasProperty('versionName') ? project.property('versionName') : '9.6.12'
+		versionCode project.hasProperty('versionCode') ? project.property('versionCode').toInteger() : 90613
+        versionName project.hasProperty('versionName') ? project.property('versionName') : '9.6.13c'
         generatedDensities = []
 		testInstrumentationRunner 'io.github.landwarderer.futon.HiltTestRunner'
 		ksp {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
 	package="io.github.landwarderer.futon"
-	android:versionCode="90612"
-	android:versionName="9.6.12"
+	android:versionCode="90613"
+	android:versionName="9.6.13"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools">
 

--- a/app/src/main/kotlin/io/github/landwarderer/futon/core/BaseApp.kt
+++ b/app/src/main/kotlin/io/github/landwarderer/futon/core/BaseApp.kt
@@ -116,10 +116,25 @@ open class BaseApp : Application(), Configuration.Provider {
 					options.isEnableAutoSessionTracking = true
 					options.environment = if (BuildConfig.DEBUG) "debug" else "production"
 				}
+				options.beforeSend = io.sentry.SentryOptions.BeforeSendCallback { event, _ ->
+					val exceptions = event.exceptions
+					if (exceptions != null && exceptions.any { it.isHttpError() }) null else event
+				}
 			}
 		} catch (e: Exception) {
 			// Log error but don't crash if Sentry initialization fails
 			e.printStackTrace()
 		}
+	}
+
+	private fun io.sentry.protocol.SentryException.isHttpError(): Boolean {
+		val name = type ?: return false
+		return name == "HttpException" ||
+			name.endsWith(".HttpException") ||
+			name == "SentryHttpClientException" ||
+			name == "SocketTimeoutException" ||
+			name == "UnknownHostException" ||
+			name == "ConnectException" ||
+			name == "SSLException"
 	}
 }

--- a/app/src/main/kotlin/io/github/landwarderer/futon/core/github/AppUpdateRepository.kt
+++ b/app/src/main/kotlin/io/github/landwarderer/futon/core/github/AppUpdateRepository.kt
@@ -27,7 +27,7 @@ class AppUpdateRepository @Inject constructor(
 	@BaseHttpClient private val okHttp: OkHttpClient,
 	@ApplicationContext context: Context,
 ) {
-TODO("Fix update checking.")
+// TODO("Fix update checking.")
 	private val availableUpdate = MutableStateFlow<AppVersion?>(null)
 	private val latestReleaseUrl = buildString {
 		append("https://api.github.com/repos/")

--- a/app/src/main/kotlin/io/github/landwarderer/futon/core/github/AppUpdateRepository.kt
+++ b/app/src/main/kotlin/io/github/landwarderer/futon/core/github/AppUpdateRepository.kt
@@ -27,7 +27,7 @@ class AppUpdateRepository @Inject constructor(
 	@BaseHttpClient private val okHttp: OkHttpClient,
 	@ApplicationContext context: Context,
 ) {
-
+TODO("Fix update checking.")
 	private val availableUpdate = MutableStateFlow<AppVersion?>(null)
 	private val latestReleaseUrl = buildString {
 		append("https://api.github.com/repos/")

--- a/metadata/changelogs/90611.txt
+++ b/metadata/changelogs/90611.txt
@@ -1,4 +1,4 @@
- cAdded 'Reading' quick filter and other improvements.
+Added 'Reading' quick filter and other improvements.
 
 Highlights:
 - Added 'Reading' quick filter (#30).

--- a/metadata/changelogs/90612.txt
+++ b/metadata/changelogs/90612.txt
@@ -1,4 +1,4 @@
- cAdded opt-in crash analytics and other improvements.
+Added opt-in crash analytics and other improvements.
 
 Highlights:
 - Added opt-in crash analytics (Sentry) — disabled by default, can be enabled in Settings.

--- a/metadata/changelogs/90613.txt
+++ b/metadata/changelogs/90613.txt
@@ -1,0 +1,1 @@
+Made crash analytics opt-in only and fixed build fail due to missing Sentry auth token.


### PR DESCRIPTION
- Bump version to 9.6.13.
- Update changelog with historical release dates and a roadmap for 9.7.
- Fix build failure caused by a missing Sentry auth token.
- Ensure crash analytics are opt-in only.
- Fix typos in existing metadata changelogs.
- Reduce unnecessary logs
