### PR TITLE
fix(browser): hide spinner on main-frame load errors in BrowserClient

### DIFF
--- a/app/src/main/kotlin/io/github/landwarderer/futon/browser/BrowserClient.kt
+++ b/app/src/main/kotlin/io/github/landwarderer/futon/browser/BrowserClient.kt
@@ -3,6 +3,7 @@ package io.github.landwarderer.futon.browser
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.os.Looper
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -31,6 +32,21 @@ open class BrowserClient(
 	override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
 		super.onPageStarted(view, url, favicon)
 		callback.onLoadingStateChanged(isLoading = true)
+	}
+
+	override fun onReceivedError(
+		view: WebView?,
+		request: WebResourceRequest?,
+		error: WebResourceError?,
+	) {
+		super.onReceivedError(view, request, error)
+		// Drop the spinner on main-frame failures (DNS, certificate, offline,
+		// 4xx/5xx) too, since onPageFinished does not always fire after an
+		// error and the BrowserCallback would otherwise stay stuck on
+		// isLoading = true.
+		if (request?.isForMainFrame == true) {
+			callback.onLoadingStateChanged(isLoading = false)
+		}
 	}
 
 	override fun onPageCommitVisible(view: WebView, url: String) {


### PR DESCRIPTION
Closes #67.

`BrowserClient` flips `BrowserCallback.onLoadingStateChanged` on `onPageStarted` (true) and `onPageFinished` (false), but does not override `onReceivedError`. On many failure modes (DNS, certificate, offline, 4xx/5xx) `onPageFinished` does not always fire after the error, so the toolbar / progress UI stays stuck on `isLoading = true` even though the page never loaded.

Add a main-frame-only `onReceivedError` override that flips `isLoading = false` too:

```kotlin
override fun onReceivedError(
    view: WebView?,
    request: WebResourceRequest?,
    error: WebResourceError?,
) {
    super.onReceivedError(view, request, error)
    if (request?.isForMainFrame == true) {
        callback.onLoadingStateChanged(isLoading = false)
    }
}
```

`isForMainFrame` keeps a single blocked sub-resource from flipping the spinner off while the main load is still running.
